### PR TITLE
added utf8 encoding to file-read call

### DIFF
--- a/gutentag_xml_cleaner.ipynb
+++ b/gutentag_xml_cleaner.ipynb
@@ -143,7 +143,7 @@
    "outputs": [],
    "source": [
     "def text_to_dataframe(f_path):\n",
-    "    file = open(f_path, 'rt')\n",
+    "    file = open(f_path, 'rt', encoding='utf8')\n",
     "    text = file.read()\n",
     "    file.close()\n",
     "    sent = sent_tokenize(text)\n",


### PR DESCRIPTION
I was getting a `UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 1178: character maps to <undefined>`  when parsing `Lovelace.txt`, adding the utf8 encoding to the open call fixes that.